### PR TITLE
Add default warning and critical tresholds

### DIFF
--- a/check_cisco_nexus/check_cisco_nexus_cpu.pl
+++ b/check_cisco_nexus/check_cisco_nexus_cpu.pl
@@ -93,7 +93,9 @@ if ($snmp eq "3") {
 	}
 }
 
-($opt_C) || ($opt_C = shift) || ($opt_C = "public");
+$opt_C ||= 'public';
+$opt_w ||= '80,70,60';
+$opt_c ||= '90,80,70';
 
 my $name = $0;
 $name =~ s/\.pl.*//g;
@@ -226,8 +228,8 @@ sub print_usage () {
     print "   -V (--version)    Plugin version\n";
     print "   -h (--help)       usage help\n\n" ;
     print "   -i (--sysdescr)   use sysdescr instead of sysname for label display\n";
-    print "   -w (--warning)    pass 3 values for warning threshold (5 seconds, 1 minute and 5 minutes cpu average usage in %)\n" ;
-    print "   -c (--critical)   pass 3 values for critical threshold (5 seconds, 1 minute and 5 minutes cpu average usage in %)\n" ;
+    print "   -w (--warning)    pass 3 values for warning threshold (5 seconds, 1 minute and 5 minutes cpu average usage in %, default is '80,70,60')\n" ;
+    print "   -c (--critical)   pass 3 values for critical threshold (5 seconds, 1 minute and 5 minutes cpu average usage in %, default is '90,80,70')\n" ;
     print "\n" ;
     print "   -d (--debug)      debug level (1 -> 15)" ;
 }


### PR DESCRIPTION
Hello,

I think that default treshold values could avoid:

```
Use of uninitialized value in numeric gt (>) at ./check_cisco_nexus_cpu.pl line 192.
Use of uninitialized value in numeric gt (>) at ./check_cisco_nexus_cpu.pl line 193.
[SNIP]