### PR TITLE
fix for potential conflicts of variable names in perf string

### DIFF
--- a/check_cisco_nexus/check_cisco_nexus_hardware.pl
+++ b/check_cisco_nexus/check_cisco_nexus_hardware.pl
@@ -465,7 +465,7 @@ while ((my $id, $sensor) = each(%nexus_sensors)) {
 			$ent_description =~ s/,//g;
 			#sometimes the entPhysicalDescr is the same for more than one sensor.
 			#let's add "id" to differentiate the variable name in perf data
-            $ent_description .= '_' . $sensor_data{"id"};
+			$ent_description .= '_' . $sensor_data{"id"};
 			push(@perfparse, $ent_description . "=" . $sensor_data{&entSensorValue} . $nexus_sensors_type[ $sensor_data{&entSensorType} ] . ";;;;");
 		}
 

--- a/check_cisco_nexus/check_cisco_nexus_hardware.pl
+++ b/check_cisco_nexus/check_cisco_nexus_hardware.pl
@@ -463,6 +463,9 @@ while ((my $id, $sensor) = each(%nexus_sensors)) {
 			my $ent_description = $nexus_entphysical{$id}{&entPhysicalDescr};
 			$ent_description =~ s/\s/_/g;
 			$ent_description =~ s/,//g;
+			#sometimes the entPhysicalDescr is the same for more than one sensor.
+			#let's add "id" to differentiate the variable name in perf data
+            $ent_description .= '_' . $sensor_data{"id"};
 			push(@perfparse, $ent_description . "=" . $sensor_data{&entSensorValue} . $nexus_sensors_type[ $sensor_data{&entSensorType} ] . ";;;;");
 		}
 


### PR DESCRIPTION
We found that in some cases multiple sensors can have the same string in entPhysicalDescr. In that case the perf string defines multiple metrics variables with the same name and that can potentialy create problem when processing the metrics data. We should add "id" of each sensor to the variable name to avoid these types of conflict