### PR TITLE
fix regex to match ints with lane number in desc

### DIFF
--- a/check_cisco_nexus/check_cisco_nexus_hardware.pl
+++ b/check_cisco_nexus/check_cisco_nexus_hardware.pl
@@ -404,7 +404,7 @@ while( (my $id,$sensor) = each(%nexus_sensors)) {
         if ($worse_sensor_status ne NEXUS_OK) {
                 verbose("add new sensor status for sensor_id = ".$sensor_data{"id"}." (".get_nexus_component_location($id).") rc=".$nexus_return_code[$sensor_alarm].". type is =".$nexus_sensors_type[$sensor_data{&entSensorType}], 15) ;
                 # skip alert if interface is Admin down
-                if ($opt_a and $nexus_entphysical{$id}{&entPhysicalDescr} =~ /(\S+) Transceiver/ and defined $nexus_interface{$1} and $nexus_interface{$1} != 1) {
+                if ($opt_a and $nexus_entphysical{$id}{&entPhysicalDescr} =~ /(\S+)( Lane \d+)? Transceiver/ and defined $nexus_interface{$1} and $nexus_interface{$1} != 1) {
                         verbose("not alerting on Transceiver with with interface in state ".$nexus_admin_status[$nexus_interface{$1}], 10);
                 } else {
                         $number_of_failed_sensors++ ;


### PR DESCRIPTION
  This will now match items such as:
  "Ethernet3/36 Lane 1 Transceiver Bias Current Sensor ..."

Some of our interfaces were not being filtered by the `-a` option
even though the interface was administratively disabled.  This
caused alerts when optics were plugged in but not cabled yet.

Upon inspection, I see some physical descriptions were not matching
properly, such as:

Ethernet3/36 Lane 1 Transceiver Bias Current Sensor->Transceiver(slot:3-port:36)->Linecard-3 Port-36->1/10 Gbps Ethernet Module->LinecardSlot-3->Nexus7000 C7009 (9 Slot) Chassis->Fabric Stack Root
